### PR TITLE
Add CircleCI configuration to run tests on Python 3 + fix several Python 3 issues

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -23,7 +23,7 @@ test:
     - make clean
     - make venv "VIRTUALENV=virtualenv -p /usr/bin/python3"
     - cd venv/lib/python3.4/site-packages; ln -s $(python3.4 -c "import PyQt4; print (PyQt4.__path__[0])"); ln -s $(python3.4 -c "import sip; print(sip.__file__)");
-    - make test 
+    - make test PACKAGES="pytest-fixture-config pytest-shutil pytest-virtualenv"
      
 machine:
   services :

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ dependencies:
     - source /etc/lsb-release && echo "deb http://download.rethinkdb.com/apt $DISTRIB_CODENAME main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
     - wget -qO- https://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
     - sudo apt-get update
-    - sudo apt-get install -y rethinkdb jenkins python-qt4
+    - sudo apt-get install -y rethinkdb jenkins python-qt4 python3-pyqt4
 
 test:
   override:
@@ -18,6 +18,12 @@ test:
     - venv/bin/coverage combine pytest-*/.coverage 
     - venv/bin/coverage html -d $CIRCLE_ARTIFACTS/htmlcov
     - cp pytest-*/dist/* $CIRCLE_ARTIFACTS
+
+    # Run tests on Python 3
+    - make clean
+    - make venv "VIRTUALENV=virtualenv -p /usr/bin/python3"
+    - cd venv/lib/python3.4/site-packages; ln -s $(python3.4 -c "import PyQt4; print (PyQt4.__path__[0])"); ln -s $(python3.4 -c "import sip; print(sip.__file__)");
+    - make test 
      
 machine:
   services :

--- a/pytest-fixture-config/pytest_fixture_config.py
+++ b/pytest-fixture-config/pytest_fixture_config.py
@@ -40,11 +40,11 @@ def yield_requires_config(cfg, vars_):
     def decorator(f):
         # We need to specify 'request' in the args here to satisfy pytest's fixture logic
         @functools.wraps(f)
-        def wrapper(request, *args, **kwargs):
+        def wrapper(*args, **kwargs):
             for var in vars_:
                 if not getattr(cfg, var):
                     pytest.skip('config variable {} missing, skipping test'.format(var))
             gen = f(*args, **kwargs)
-            yield gen.next()
+            yield next(gen)
         return wrapper
     return decorator

--- a/pytest-server-fixtures/pytest_server_fixtures/rethink.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/rethink.py
@@ -91,7 +91,7 @@ def rethink_make_tables(request, rethink_module_db):
                                                ).run(conn)
             log.info('Made table "{}" with key "{}"'
                      .format(table_name, primary_key))
-        except rethinkdb.errors.RqlRuntimeError, err:
+        except rethinkdb.errors.RqlRuntimeError as err:
             log.debug('Table "{}" not made: {}'.format(table_name, err.message))
 
 

--- a/pytest-shutil/pytest_shutil/run.py
+++ b/pytest-shutil/pytest_shutil/run.py
@@ -136,7 +136,7 @@ def _make_pickleable(fn):
     # could use partial but this is more efficient
     try:
         cPickle.dumps(fn, protocol=0)
-    except TypeError:
+    except (TypeError, cPickle.PickleError):
         pass
     else:
         return fn, ()

--- a/pytest-shutil/pytest_shutil/workspace.py
+++ b/pytest-shutil/pytest_shutil/workspace.py
@@ -9,7 +9,7 @@ import subprocess
 from path import path
 from six import string_types
 
-import cmdline
+from . import cmdline
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
I fixed running tests on Python 3 for `pytest-fixture-config`, `pytest-shutil` and `pytest-virtualenv`.

Other libraries tests fails, so I didn't enabled them currently for Python 3.

This PR includes fix from #14 and partly fixes #15.
