### PR TITLE
virtualenv/installed_packages: Add support for windows

### DIFF
--- a/pytest-virtualenv/pytest_virtualenv.py
+++ b/pytest-virtualenv/pytest_virtualenv.py
@@ -214,7 +214,7 @@ class VirtualEnv(Workspace):
         res = {}
         code = "from pkg_resources import working_set\n"\
                "for i in working_set: print(i.project_name + ' ' + i.version + ' ' + i.location)"
-        lines = self.run('%s -c "%s"' % (self.python, code), capture=True).split('\n')
+        lines = self.run([self.python, "-c", code], capture=True).split('\n')
         for line in [i.strip() for i in lines if i.strip()]:
             name, version, location = line.split()
             res[name] = PackageEntry(name, version, location)


### PR DESCRIPTION
Invoking "installed_packages" on windows fails because it is trying to
execute multi-line python code as a string with "shell=true". In that
case, "cmd.exe" fails because it does NOT know how to handle newline
character.  This confirmed by example (2) reported below.

Instead, this commit passes the command as an array of arguments that
ends up calling subprocess.Popen with "shell=false".

Examples:

1) Executing "import sys; print(sys.path)": OK

```
C:\Users\appveyor>cmd.exe /c python -c "import sys; print(sys.path)"
['', 'C:\\windows\\SYSTEM32\\python27.zip', 'C:\\Python27\\DLLs', 'C:\\Python27\
\lib', 'C:\\Python27\\lib\\plat-win', 'C:\\Python27\\lib\\lib-tk', 'C:\\Python27
', 'C:\\Python27\\lib\\site-packages']
```

2) Executing "import sys\nfor p in sys.path: print(p)": FAIL

```
C:\Users\appveyor>cmd.exe /c python -c "import sys\nfor p in sys.path: print(p)"

  File "<string>", line 1
    import sys\nfor p in sys.path: print(p)
                                          ^
SyntaxError: unexpected character after line continuation character
```