### PR TITLE
Fix issue 42

### DIFF
--- a/pytest-server-fixtures/pytest_server_fixtures/base.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/base.py
@@ -151,8 +151,12 @@ class TestServer(Workspace):
 
     def __init__(self, workspace=None, delete=None, preserve_sys_path=False, **kwargs):
         super(TestServer, self).__init__(workspace=workspace, delete=delete)
-        self.hostname = kwargs.get('hostname', get_ephemeral_host())
-        self.port = kwargs.get('port', self.get_port())
+        self.hostname = kwargs.get('hostname')
+        if self.hostname is None:
+            get_ephemeral_host()
+        self.port = kwargs.get('port')
+        if self.port is None:
+            self.get_port()
         # We don't know if the server is alive or dead at this point, assume alive
         self.dead = False
         self.env = kwargs.get('env')

--- a/pytest-server-fixtures/pytest_server_fixtures/base.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/base.py
@@ -47,7 +47,7 @@ def get_ephemeral_host():
         except socket.error:
             pass
 
-def get_ephemeral_port(host=get_ephemeral_host()):
+def get_ephemeral_port(host=None):
     """
     Get an ephemeral socket at random from the kernel.
 
@@ -61,6 +61,8 @@ def get_ephemeral_port(host=get_ephemeral_host()):
     -------
     Available port to use
     """
+    if host is None:
+        host = get_ephemeral_host()
     port = random.randrange(1024, 32768)
 
     while True:

--- a/pytest-server-fixtures/pytest_server_fixtures/base.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/base.py
@@ -20,7 +20,7 @@ from pytest_server_fixtures import CONFIG
 from pytest_shutil.workspace import Workspace
 
 log = logging.getLogger(__name__)
-_SESSION_HOST
+_SESSION_HOST = None
 
 
 def get_ephemeral_host():

--- a/pytest-server-fixtures/pytest_server_fixtures/base.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/base.py
@@ -151,12 +151,8 @@ class TestServer(Workspace):
 
     def __init__(self, workspace=None, delete=None, preserve_sys_path=False, **kwargs):
         super(TestServer, self).__init__(workspace=workspace, delete=delete)
-        self.hostname = kwargs.get('hostname')
-        if self.hostname is None:
-            get_ephemeral_host()
-        self.port = kwargs.get('port')
-        if self.port is None:
-            self.get_port()
+        self.hostname = kwargs.get('hostname') or get_ephemeral_host()
+        self.port = kwargs.get('port') or self.get_port()
         # We don't know if the server is alive or dead at this point, assume alive
         self.dead = False
         self.env = kwargs.get('env')

--- a/pytest-server-fixtures/pytest_server_fixtures/base.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/base.py
@@ -61,6 +61,8 @@ def get_ephemeral_port(host=get_ephemeral_host()):
     -------
     Available port to use
     """
+    port = random.randrange(1024, 32768)
+
     while True:
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:

--- a/pytest-server-fixtures/pytest_server_fixtures/base.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/base.py
@@ -13,6 +13,7 @@ import time
 import traceback
 from datetime import datetime
 import logging
+import random
 
 from six import string_types
 

--- a/pytest-server-fixtures/pytest_server_fixtures/rethink.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/rethink.py
@@ -18,7 +18,7 @@ def _rethink_server(request):
     """ This does the actual work - there are several versions of this used
         with different scopes.
     """
-    test_server = RethinkDBServer()
+    test_server = RethinkDBServer(hostname=CONFIG.fixture_hostname)
     request.addfinalizer(lambda p=test_server: p.teardown())
     test_server.start()
     return test_server


### PR DESCRIPTION
Change the behavior of the test server in the server fixtures to behave in one of two ways:

if a hostname is not specified, use a random ip/port to connect to the instance. 

if a hostname is specified, that will be used to connect. 

Hostname is config is no longer used. 