### PR TITLE
Fix #44 - don't try to bind a random port.

### DIFF
--- a/pytest-server-fixtures/pytest_server_fixtures/base.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/base.py
@@ -22,6 +22,8 @@ from pytest_shutil.workspace import Workspace
 log = logging.getLogger(__name__)
 _SESSION_HOST = None
 
+OSX = sys.platform == 'darwin'
+
 
 def get_ephemeral_host():
     """
@@ -36,7 +38,14 @@ def get_ephemeral_host():
     while True:
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            host = '127.0.0.1'
+            # MacOS / OSX does not support loopback ip addresses other than
+            # 127.0.0.1 unless they are manually configured (unlike linux)
+            if OSX:
+                host = '127.0.0.1'
+            else:
+                host = '127.{}.{}.{}'.format(random.randrange(1, 255),
+                                             random.randrange(1, 255),		
+                                             random.randrange(2, 255))
             s.bind((host, 5000))
             s.listen(0)
             _SESSION_HOST = (host, s)

--- a/pytest-server-fixtures/pytest_server_fixtures/base.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/base.py
@@ -36,9 +36,7 @@ def get_ephemeral_host():
     while True:
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            host = '127.{}.{}.{}'.format(random.randrange(1, 255),
-                                         random.randrange(1, 255),
-                                         random.randrange(2, 255),)
+            host = '127.0.0.1'
             s.bind((host, 5000))
             s.listen(0)
             _SESSION_HOST = (host, s)


### PR DESCRIPTION
This hangs indefinitely on macOS for an unknown reason.

I confirmed that this fix works for me on my machine