### PR TITLE
fix workspace/virtualenv automatic deletion after use

### DIFF
--- a/pytest-shutil/pytest_shutil/workspace.py
+++ b/pytest-shutil/pytest_shutil/workspace.py
@@ -134,7 +134,7 @@ class Workspace(object):
         return out
 
     def teardown(self):
-        if not self.delete:
+        if self.delete is not None and not self.delete:
             return
         if self.workspace.isdir():
             log.debug("")

--- a/pytest-shutil/tests/integration/test_run_integration.py
+++ b/pytest-shutil/tests/integration/test_run_integration.py
@@ -240,3 +240,9 @@ run_in_subprocess(%r)(%r)
         p = subprocess.Popen([sys.executable, '-c', cmd], stderr=subprocess.PIPE)
     (_, err) = p.communicate()
     assert guid in err.decode('ascii')
+
+
+def test_workspace_autodelete():
+    ws = workspace.Workspace()
+    ws.teardown()
+    assert not ws.workspace.exists()

--- a/pytest-shutil/tests/integration/test_workspace_integration.py
+++ b/pytest-shutil/tests/integration/test_workspace_integration.py
@@ -1,5 +1,7 @@
+import os
 import subprocess
 import sys
+import textwrap
 
 
 def test_workspace_run_displays_output_on_failure():
@@ -18,3 +20,17 @@ else:
     assert p.returncode == 0
     assert 'stdout\n'.encode('utf-8') in out
     assert 'stderr\n'.encode('utf-8') in out
+
+
+def test_workspace_fixture_autodelete(monkeypatch, tmpdir):
+    workspace = (tmpdir / 'tmp').mkdir()
+    monkeypatch.setenv('WORKSPACE', workspace)
+    testsuite = tmpdir.join('test.py')
+    with testsuite.open('w') as fp:
+        fp.write(textwrap.dedent(
+        """
+        def test(workspace):
+            pass
+        """))
+    subprocess.check_call([sys.executable, '-m', 'pytest', testsuite])
+    assert os.listdir(workspace) == []

--- a/pytest-virtualenv/pytest_virtualenv.py
+++ b/pytest-virtualenv/pytest_virtualenv.py
@@ -46,8 +46,9 @@ def virtualenv():
         easy_install (`path.path`)  : Path to this virtualenv's easy_install executable
         .. also inherits all attributes from the `workspace` fixture
     """
-    with VirtualEnv() as venv:
-        yield venv
+    venv = VirtualEnv()
+    yield venv
+    venv.teardown()
 
 
 class PackageEntry(object):

--- a/pytest-virtualenv/tests/integration/test_tmpvirtualenv.py
+++ b/pytest-virtualenv/tests/integration/test_tmpvirtualenv.py
@@ -1,3 +1,8 @@
+import os
+import subprocess
+import sys
+import textwrap
+
 import pytest_virtualenv as venv
 
 
@@ -11,3 +16,17 @@ def test_installed_packages():
         assert len(ips) > 0
         check_member('pip', ips)
         check_member('virtualenv', ips)
+
+
+def test_virtualenv_fixture_autodelete(monkeypatch, tmpdir):
+    workspace = (tmpdir / 'tmp').mkdir()
+    monkeypatch.setenv('WORKSPACE', workspace)
+    testsuite = tmpdir.join('test.py')
+    with testsuite.open('w') as fp:
+        fp.write(textwrap.dedent(
+        """
+        def test(virtualenv):
+            pass
+        """))
+    subprocess.check_call([sys.executable, '-m', 'pytest', testsuite])
+    assert os.listdir(workspace) == []


### PR DESCRIPTION
After running out of space on my tmpfs mounted /tmp, I investigated and noticed that the virtualenv fixture was not cleaning after itself. Same issue with the workspace fixture.

This is fixed by:
* handling the special case of `delete` being `None` in `Workspace.teardown`
* explicitly calling `teardown` in the virtualenv fixture