### PR TITLE
fix mongo database_names deprecation warning

### DIFF
--- a/pytest-server-fixtures/pytest_server_fixtures/mongo.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/mongo.py
@@ -122,7 +122,7 @@ class MongoTestServer(TestServer):
         try:
             self.api = pymongo.MongoClient(self.hostname, self.port,
                                            serverselectiontimeoutms=200)
-            self.api.database_names()
+            self.api.list_database_names()
             # Configure the client with default timeouts in case the server goes slow
             self.api = pymongo.MongoClient(self.hostname, self.port)
             return True


### PR DESCRIPTION
This will fix #84 