### PR TITLE
python 3 compatibility: SimpleHTTPServer became http.server

### DIFF
--- a/pytest-server-fixtures/pytest_server_fixtures/http.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/http.py
@@ -4,6 +4,7 @@ import os
 import socket
 import logging
 import time
+import sys
 
 import pytest
 import requests
@@ -138,7 +139,8 @@ class SimpleHTTPTestServer(HTTPTestServer):
 
     @property
     def run_cmd(self):
-        return ["python", "-m", "SimpleHTTPServer", str(self.port)]
+        http_server = 'http.server' if sys.version_info >= (3,0) else 'SimpleHTTPServer'
+        return ["python", "-m", http_server, str(self.port)]
 
     @property
     def document_root(self):


### PR DESCRIPTION
python 3 compatibility: `SimpleHTTPServer` became `http.server`

see http://python-future.org/compatible_idioms.html

currently on py3 it fails with:
```
bin/python: No module named SimpleHTTPServer
```