### PR TITLE
Pin pytest to 3.10.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
  * Fixing python 3 compatibility in Simple HTTP Server fixture
  * Fixed broken tests in pytest-profiling
  * Removed pytest-fixture-config decorator 'requires_config' and 'yield_requires_config' (due to incompatibility with pytest>=3.7.1)
+ * Pinned pytest==3.10.1 until all deprecation warnings are fixed.
 
 ### 1.3.1 (2018-06-28)
  * Use pymongo list_database_names() instead of the deprecated database_names(), added pymongo>=3.6.0 dependency

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
  * Fixing python 3 compatibility in Simple HTTP Server fixture
  * Fixed broken tests in pytest-profiling
  * Removed pytest-fixture-config decorator 'requires_config' and 'yield_requires_config' (due to incompatibility with pytest>=3.7.1)
- * Pinned pytest==3.10.1 until all deprecation warnings are fixed.
+ * Pinned pytest<4.0.0 until all deprecation warnings are fixed.
 
 ### 1.3.1 (2018-06-28)
  * Use pymongo list_database_names() instead of the deprecated database_names(), added pymongo>=3.6.0 dependency

--- a/pytest-devpi-server/setup.py
+++ b/pytest-devpi-server/setup.py
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 install_requires = ['pytest-server-fixtures',
-                    'pytest==3.10.1',
+                    'pytest<4.0.0',
                     'devpi-server>=3.0.1',
                     'devpi-client',
                     'six',

--- a/pytest-devpi-server/setup.py
+++ b/pytest-devpi-server/setup.py
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 install_requires = ['pytest-server-fixtures',
-                    'pytest',
+                    'pytest==3.10.1',
                     'devpi-server>=3.0.1',
                     'devpi-client',
                     'six',

--- a/pytest-fixture-config/setup.py
+++ b/pytest-fixture-config/setup.py
@@ -21,7 +21,7 @@ classifiers = [
     'Programming Language :: Python :: 3.6',
 ]
 
-install_requires = ['pytest']
+install_requires = ['pytest==3.10.1']
 
 tests_require = ['six',
                  ]

--- a/pytest-fixture-config/setup.py
+++ b/pytest-fixture-config/setup.py
@@ -21,7 +21,7 @@ classifiers = [
     'Programming Language :: Python :: 3.6',
 ]
 
-install_requires = ['pytest==3.10.1']
+install_requires = ['pytest<4.0.0']
 
 tests_require = ['six',
                  ]

--- a/pytest-git/setup.py
+++ b/pytest-git/setup.py
@@ -21,7 +21,7 @@ classifiers = [
     'Programming Language :: Python :: 3.6',
 ]
 
-install_requires = ['pytest',
+install_requires = ['pytest==3.10.1',
                     'pytest-shutil',
                     'gitpython',
                     ]

--- a/pytest-git/setup.py
+++ b/pytest-git/setup.py
@@ -21,7 +21,7 @@ classifiers = [
     'Programming Language :: Python :: 3.6',
 ]
 
-install_requires = ['pytest==3.10.1',
+install_requires = ['pytest<4.0.0',
                     'pytest-shutil',
                     'gitpython',
                     ]

--- a/pytest-listener/setup.py
+++ b/pytest-listener/setup.py
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 install_requires = ['six',
-                    'pytest',
+                    'pytest==3.10.1',
                     'pytest-server-fixtures'
                     ]
 

--- a/pytest-listener/setup.py
+++ b/pytest-listener/setup.py
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 install_requires = ['six',
-                    'pytest==3.10.1',
+                    'pytest<4.0.0',
                     'pytest-server-fixtures'
                     ]
 

--- a/pytest-profiling/setup.py
+++ b/pytest-profiling/setup.py
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 install_requires = ['six',
-                    'pytest==3.10.1',
+                    'pytest<4.0.0',
                     'gprof2dot',
                     ]
 

--- a/pytest-profiling/setup.py
+++ b/pytest-profiling/setup.py
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 install_requires = ['six',
-                    'pytest',
+                    'pytest==3.10.1',
                     'gprof2dot',
                     ]
 

--- a/pytest-pyramid-server/setup.py
+++ b/pytest-pyramid-server/setup.py
@@ -24,7 +24,7 @@ classifiers = [
 
 
 install_requires = ['pytest-server-fixtures',
-                    'pytest==3.10.1',
+                    'pytest<4.0.0',
                     'pyramid',
                     'waitress',
                     'six',

--- a/pytest-pyramid-server/setup.py
+++ b/pytest-pyramid-server/setup.py
@@ -24,7 +24,7 @@ classifiers = [
 
 
 install_requires = ['pytest-server-fixtures',
-                    'pytest',
+                    'pytest==3.10.1',
                     'pyramid',
                     'waitress',
                     'six',

--- a/pytest-qt-app/setup.py
+++ b/pytest-qt-app/setup.py
@@ -21,7 +21,7 @@ classifiers = [
     'Programming Language :: Python :: 3.6',
 ]
 
-install_requires = ['pytest',
+install_requires = ['pytest==3.10.1',
                     'pytest-server-fixtures',
                     'pytest-shutil',
                     ]

--- a/pytest-qt-app/setup.py
+++ b/pytest-qt-app/setup.py
@@ -21,7 +21,7 @@ classifiers = [
     'Programming Language :: Python :: 3.6',
 ]
 
-install_requires = ['pytest==3.10.1',
+install_requires = ['pytest<4.0.0',
                     'pytest-server-fixtures',
                     'pytest-shutil',
                     ]

--- a/pytest-server-fixtures/setup.py
+++ b/pytest-server-fixtures/setup.py
@@ -21,7 +21,7 @@ classifiers = [
     'Programming Language :: Python :: 3.6',
 ]
 
-install_requires = ['pytest==3.10.1',
+install_requires = ['pytest<4.0.0',
                     'pytest-shutil',
                     'pytest-fixture-config',
                     'six',

--- a/pytest-server-fixtures/setup.py
+++ b/pytest-server-fixtures/setup.py
@@ -21,7 +21,7 @@ classifiers = [
     'Programming Language :: Python :: 3.6',
 ]
 
-install_requires = ['pytest',
+install_requires = ['pytest==3.10.1',
                     'pytest-shutil',
                     'pytest-fixture-config',
                     'six',

--- a/pytest-shutil/setup.py
+++ b/pytest-shutil/setup.py
@@ -24,7 +24,7 @@ classifiers = [
 install_requires = ['six',
                     'execnet',
                     'contextlib2',
-                    'pytest==3.10.1',
+                    'pytest<4.0.0',
                     'path.py',
                     'mock',
                     'termcolor'

--- a/pytest-shutil/setup.py
+++ b/pytest-shutil/setup.py
@@ -24,7 +24,7 @@ classifiers = [
 install_requires = ['six',
                     'execnet',
                     'contextlib2',
-                    'pytest',
+                    'pytest==3.10.1',
                     'path.py',
                     'mock',
                     'termcolor'

--- a/pytest-svn/setup.py
+++ b/pytest-svn/setup.py
@@ -21,7 +21,7 @@ classifiers = [
     'Programming Language :: Python :: 3.6',
 ]
 
-install_requires = ['pytest==3.10.1',
+install_requires = ['pytest<4.0.0',
                     'pytest-shutil',
                     ]
 

--- a/pytest-svn/setup.py
+++ b/pytest-svn/setup.py
@@ -21,7 +21,7 @@ classifiers = [
     'Programming Language :: Python :: 3.6',
 ]
 
-install_requires = ['pytest',
+install_requires = ['pytest==3.10.1',
                     'pytest-shutil',
                     ]
 

--- a/pytest-verbose-parametrize/setup.py
+++ b/pytest-verbose-parametrize/setup.py
@@ -21,7 +21,7 @@ classifiers = [
     'Programming Language :: Python :: 3.6',
 ]
 
-install_requires = ['pytest==3.10.1',
+install_requires = ['pytest<4.0.0',
                     'six',
                     ]
 

--- a/pytest-verbose-parametrize/setup.py
+++ b/pytest-verbose-parametrize/setup.py
@@ -21,7 +21,7 @@ classifiers = [
     'Programming Language :: Python :: 3.6',
 ]
 
-install_requires = ['pytest',
+install_requires = ['pytest==3.10.1',
                     'six',
                     ]
 

--- a/pytest-virtualenv/setup.py
+++ b/pytest-virtualenv/setup.py
@@ -23,7 +23,7 @@ classifiers = [
 
 install_requires = ['pytest-fixture-config',
                     'pytest-shutil',
-                    'pytest',
+                    'pytest==3.10.1',
                     ]
 
 tests_require = [

--- a/pytest-virtualenv/setup.py
+++ b/pytest-virtualenv/setup.py
@@ -23,7 +23,7 @@ classifiers = [
 
 install_requires = ['pytest-fixture-config',
                     'pytest-shutil',
-                    'pytest==3.10.1',
+                    'pytest<4.0.0',
                     ]
 
 tests_require = [

--- a/pytest-webdriver/setup.py
+++ b/pytest-webdriver/setup.py
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 install_requires = ['py',
-                    'pytest==3.10.1',
+                    'pytest<4.0.0',
                     'pytest-fixture-config',
                     'selenium',
                     ]

--- a/pytest-webdriver/setup.py
+++ b/pytest-webdriver/setup.py
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 install_requires = ['py',
-                    'pytest',
+                    'pytest==3.10.1',
                     'pytest-fixture-config',
                     'selenium',
                     ]


### PR DESCRIPTION
Pytest just released 4.0.0, which treats all RemovedInPytest4Warnings as errors. In the long run we probably need to fix the tests to remove all warnings instead. But we need the tests to pass for now... So pinning pytest==3.10.1