### PR TITLE
Fix fixture config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,6 @@
 ### 1.3.2 (Unreleased)
  * Fixing python 3 compatibility in Simple HTTP Server fixture
  * Fixed broken tests in pytest-profiling
- * Removed pytest-fixture-config decorator 'requires_config' and 'yield_requires_config'
  * Pinned pytest<4.0.0 until all deprecation warnings are fixed.
  * pytest-webdriver: replaced deprecated phantomjs with headless Google Chrome.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 ### 1.3.2 (Unreleased)
  * Fixing python 3 compatibility in Simple HTTP Server fixture
  * Fixed broken tests in pytest-profiling
- * Removed pytest-fixture-config decorator 'requires_config' and 'yield_requires_config' (due to incompatibility with pytest>=3.7.1)
+ * Removed pytest-fixture-config decorator 'requires_config' and 'yield_requires_config'
  * Pinned pytest<4.0.0 until all deprecation warnings are fixed.
  * pytest-webdriver: replaced deprecated phantomjs with headless Google Chrome.
 

--- a/pytest-fixture-config/README.md
+++ b/pytest-fixture-config/README.md
@@ -63,8 +63,8 @@ but don't want your tests suite to fail:
 ```python
     from pytest_fixture_config import requires_config
     
-    @requires_config(CONFIG, ['log_watcher', 'log_dir'])
     @pytest.fixture
+    @requires_config(CONFIG, ['log_watcher', 'log_dir'])
     def log_watcher():
         return subprocess.popen([CONFIG.log_watcher, '--log-dir', CONFIG.log_dir])
 ```
@@ -74,8 +74,8 @@ There is also a version for yield_fixtures:
 ```python
     from pytest_fixture_config import yield_requires_config
     
-    @yield_requires_config(CONFIG, ['log_watcher', 'log_dir'])
     @pytest.fixture
+    @yield_requires_config(CONFIG, ['log_watcher', 'log_dir'])
     def log_watcher():
         watcher = subprocess.popen([CONFIG.log_watcher, '--log-dir', CONFIG.log_dir])
         yield watcher

--- a/pytest-fixture-config/README.md
+++ b/pytest-fixture-config/README.md
@@ -54,3 +54,30 @@ Simply reference the singleton at run-time in your fixtures:
         watcher.communicate()
 ```
 
+## Skipping tests when things are missing
+
+There are some decorators that allow you to skip tests when settings aren't set.
+This is useful when you're testing something you might not have installed
+but don't want your tests suite to fail:
+
+```python
+    from pytest_fixture_config import requires_config
+    
+    @requires_config(CONFIG, ['log_watcher', 'log_dir'])
+    @pytest.fixture
+    def log_watcher():
+        return subprocess.popen([CONFIG.log_watcher, '--log-dir', CONFIG.log_dir])
+```
+    
+There is also a version for yield_fixtures:
+
+```python
+    from pytest_fixture_config import yield_requires_config
+    
+    @yield_requires_config(CONFIG, ['log_watcher', 'log_dir'])
+    @pytest.fixture
+    def log_watcher():
+        watcher = subprocess.popen([CONFIG.log_watcher, '--log-dir', CONFIG.log_dir])
+        yield watcher
+        watcher.kill()
+```

--- a/pytest-fixture-config/pytest_fixture_config.py
+++ b/pytest-fixture-config/pytest_fixture_config.py
@@ -1,5 +1,9 @@
 """ Fixture configuration
 """
+import functools
+
+import pytest
+
 
 class Config(object):
     __slots__ = ()
@@ -13,3 +17,33 @@ class Config(object):
                 raise ValueError("Unknown config option: {0}".format(k))
             setattr(self, k, cfg[k])
 
+
+def requires_config(cfg, vars_):
+    """ Decorator for fixtures that will skip tests if the required config variables
+        are missing or undefined in the configuration
+    """
+    def decorator(f):
+        # We need to specify 'request' in the args here to satisfy pytest's fixture logic
+        @functools.wraps(f)
+        def wrapper(request, *args, **kwargs):
+            for var in vars_:
+                if not getattr(cfg, var):
+                    pytest.skip('config variable {0} missing, skipping test'.format(var))
+            return f(request, *args, **kwargs)
+        return wrapper
+    return decorator
+
+
+def yield_requires_config(cfg, vars_):
+    """ As above but for py.test yield_fixtures
+    """
+    def decorator(f):
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            for var in vars_:
+                if not getattr(cfg, var):
+                    pytest.skip('config variable {0} missing, skipping test'.format(var))
+            gen = f(*args, **kwargs)
+            yield next(gen)
+        return wrapper
+    return decorator

--- a/pytest-fixture-config/tests/unit/test_fixture_config.py
+++ b/pytest-fixture-config/tests/unit/test_fixture_config.py
@@ -26,8 +26,8 @@ def test_config_update():
 
 CONFIG1 = DummyConfig(foo=None, bar=1)
 
-@requires_config(CONFIG1, ('foo', 'bar'))
 @pytest.fixture
+@requires_config(CONFIG1, ('foo', 'bar'))
 def a_fixture(request):
     raise ValueError('Should not run')
 
@@ -36,8 +36,8 @@ def test_requires_config_skips(a_fixture):
     raise ValueError('Should not run')
 
 
-@requires_config(CONFIG1, ('bar',))
 @pytest.fixture
+@requires_config(CONFIG1, ('bar',))
 def another_fixture(request):
     return 'xxxx'
 
@@ -47,8 +47,8 @@ def test_requires_config_doesnt_skip(another_fixture):
     
     
 
-@yield_requires_config(CONFIG1, ('foo', 'bar'))
 @pytest.yield_fixture
+@yield_requires_config(CONFIG1, ('foo', 'bar'))
 def yet_another_fixture():
     raise ValueError('Should also not run')
     yield 'yyyy'
@@ -58,8 +58,8 @@ def test_yield_requires_config_skips(yet_another_fixture):
     raise ValueError('Should also not run')
 
 
-@yield_requires_config(CONFIG1, ('bar',))
 @pytest.yield_fixture
+@yield_requires_config(CONFIG1, ('bar',))
 def yet_some_other_fixture():
     yield 'yyyy'
 

--- a/pytest-fixture-config/tests/unit/test_fixture_config.py
+++ b/pytest-fixture-config/tests/unit/test_fixture_config.py
@@ -7,7 +7,7 @@ from six.moves import reload_module
 import pytest_fixture_config
 reload_module(pytest_fixture_config)
 
-from pytest_fixture_config import Config
+from pytest_fixture_config import Config, requires_config, yield_requires_config
 
 class DummyConfig(Config):
     __slots__ = ('foo', 'bar')
@@ -23,3 +23,46 @@ def test_config_update():
     with pytest.raises(ValueError):
         cfg.update({"baz": 30})
 
+
+CONFIG1 = DummyConfig(foo=None, bar=1)
+
+@requires_config(CONFIG1, ('foo', 'bar'))
+@pytest.fixture
+def a_fixture(request):
+    raise ValueError('Should not run')
+
+
+def test_requires_config_skips(a_fixture):
+    raise ValueError('Should not run')
+
+
+@requires_config(CONFIG1, ('bar',))
+@pytest.fixture
+def another_fixture(request):
+    return 'xxxx'
+
+
+def test_requires_config_doesnt_skip(another_fixture):
+    assert another_fixture == 'xxxx'
+    
+    
+
+@yield_requires_config(CONFIG1, ('foo', 'bar'))
+@pytest.yield_fixture
+def yet_another_fixture():
+    raise ValueError('Should also not run')
+    yield 'yyyy'
+
+
+def test_yield_requires_config_skips(yet_another_fixture):
+    raise ValueError('Should also not run')
+
+
+@yield_requires_config(CONFIG1, ('bar',))
+@pytest.yield_fixture
+def yet_some_other_fixture():
+    yield 'yyyy'
+
+
+def test_yield_requires_config_doesnt_skip(yet_some_other_fixture):
+    assert yet_some_other_fixture == 'yyyy'

--- a/pytest-server-fixtures/pytest_server_fixtures/httpd.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/httpd.py
@@ -9,6 +9,7 @@ try:
 except ImportError:
     from path import path as Path
 
+from pytest_fixture_config import yield_requires_config
 from pytest_server_fixtures import CONFIG
 
 from .http import HTTPTestServer
@@ -16,6 +17,7 @@ from .http import HTTPTestServer
 log = logging.getLogger(__name__)
 
 
+@yield_requires_config(CONFIG, ['httpd_executable', 'httpd_modules'])
 @pytest.yield_fixture(scope='function')
 def httpd_server():
     """ Function-scoped httpd server in a local thread.

--- a/pytest-server-fixtures/pytest_server_fixtures/httpd.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/httpd.py
@@ -17,8 +17,8 @@ from .http import HTTPTestServer
 log = logging.getLogger(__name__)
 
 
-@yield_requires_config(CONFIG, ['httpd_executable', 'httpd_modules'])
 @pytest.yield_fixture(scope='function')
+@yield_requires_config(CONFIG, ['httpd_executable', 'httpd_modules'])
 def httpd_server():
     """ Function-scoped httpd server in a local thread.
     

--- a/pytest-server-fixtures/pytest_server_fixtures/jenkins.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/jenkins.py
@@ -12,10 +12,12 @@ import pytest
 import six
 
 from pytest_server_fixtures import CONFIG
+from pytest_fixture_config import yield_requires_config
 
 from .http import HTTPTestServer
 
 
+@yield_requires_config(CONFIG, ['jenkins_war', 'java_executable'])
 @pytest.yield_fixture(scope='session')
 def jenkins_server():
     """ Session-scoped Jenkins server instance
@@ -30,6 +32,7 @@ def jenkins_server():
         yield p
 
 
+@yield_requires_config(CONFIG, ['jenkins_war', 'java_executable'])
 @pytest.yield_fixture(scope='module')
 def jenkins_server_module():
     """ Module-scoped Jenkins server instance

--- a/pytest-server-fixtures/pytest_server_fixtures/jenkins.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/jenkins.py
@@ -17,8 +17,8 @@ from pytest_fixture_config import yield_requires_config
 from .http import HTTPTestServer
 
 
-@yield_requires_config(CONFIG, ['jenkins_war', 'java_executable'])
 @pytest.yield_fixture(scope='session')
+@yield_requires_config(CONFIG, ['jenkins_war', 'java_executable'])
 def jenkins_server():
     """ Session-scoped Jenkins server instance
 
@@ -32,8 +32,8 @@ def jenkins_server():
         yield p
 
 
-@yield_requires_config(CONFIG, ['jenkins_war', 'java_executable'])
 @pytest.yield_fixture(scope='module')
+@yield_requires_config(CONFIG, ['jenkins_war', 'java_executable'])
 def jenkins_server_module():
     """ Module-scoped Jenkins server instance
 

--- a/pytest-server-fixtures/pytest_server_fixtures/mongo.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/mongo.py
@@ -10,6 +10,7 @@ import getpass
 import pytest
 
 from pytest_server_fixtures import CONFIG
+from pytest_fixture_config import yield_requires_config
 
 from .base import TestServer
 
@@ -28,6 +29,7 @@ def _mongo_server():
         test_server.teardown()
 
 
+@yield_requires_config(CONFIG, ['mongo_bin'])
 @pytest.yield_fixture(scope='function')
 def mongo_server():
     """ Function-scoped MongoDB server started in a local thread.
@@ -46,6 +48,7 @@ def mongo_server():
         yield server
 
 
+@yield_requires_config(CONFIG, ['mongo_bin'])
 @pytest.yield_fixture(scope='session')
 def mongo_server_sess():
     """ Same as mongo_server fixture, scoped as session instead.
@@ -54,6 +57,7 @@ def mongo_server_sess():
         yield server
 
 
+@yield_requires_config(CONFIG, ['mongo_bin'])
 @pytest.yield_fixture(scope='class')
 def mongo_server_cls(request):
     """ Same as mongo_server fixture, scoped for test classes.
@@ -63,6 +67,7 @@ def mongo_server_cls(request):
         yield server
 
 
+@yield_requires_config(CONFIG, ['mongo_bin'])
 @pytest.yield_fixture(scope='module')
 def mongo_server_module():
     """ Same as mongo_server fixture, scoped for test modules.

--- a/pytest-server-fixtures/pytest_server_fixtures/mongo.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/mongo.py
@@ -29,8 +29,8 @@ def _mongo_server():
         test_server.teardown()
 
 
-@yield_requires_config(CONFIG, ['mongo_bin'])
 @pytest.yield_fixture(scope='function')
+@yield_requires_config(CONFIG, ['mongo_bin'])
 def mongo_server():
     """ Function-scoped MongoDB server started in a local thread.
         This also provides a temp workspace.
@@ -48,8 +48,8 @@ def mongo_server():
         yield server
 
 
-@yield_requires_config(CONFIG, ['mongo_bin'])
 @pytest.yield_fixture(scope='session')
+@yield_requires_config(CONFIG, ['mongo_bin'])
 def mongo_server_sess():
     """ Same as mongo_server fixture, scoped as session instead.
     """
@@ -57,8 +57,8 @@ def mongo_server_sess():
         yield server
 
 
-@yield_requires_config(CONFIG, ['mongo_bin'])
 @pytest.yield_fixture(scope='class')
+@yield_requires_config(CONFIG, ['mongo_bin'])
 def mongo_server_cls(request):
     """ Same as mongo_server fixture, scoped for test classes.
     """
@@ -67,8 +67,8 @@ def mongo_server_cls(request):
         yield server
 
 
-@yield_requires_config(CONFIG, ['mongo_bin'])
 @pytest.yield_fixture(scope='module')
+@yield_requires_config(CONFIG, ['mongo_bin'])
 def mongo_server_module():
     """ Same as mongo_server fixture, scoped for test modules.
     """

--- a/pytest-server-fixtures/pytest_server_fixtures/redis.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/redis.py
@@ -25,8 +25,8 @@ def _redis_server(request):
     return test_server
 
 
-@requires_config(CONFIG, ['redis_executable'])
 @pytest.fixture(scope='function')
+@requires_config(CONFIG, ['redis_executable'])
 def redis_server(request):
     """ Function-scoped Redis server in a local thread.
 
@@ -38,8 +38,8 @@ def redis_server(request):
     return _redis_server(request)
 
 
-@requires_config(CONFIG, ['redis_executable'])
 @pytest.fixture(scope='session')
+@requires_config(CONFIG, ['redis_executable'])
 def redis_server_sess(request):
     """ Same as redis_server fixture, scoped for test session
     """

--- a/pytest-server-fixtures/pytest_server_fixtures/redis.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/redis.py
@@ -10,6 +10,7 @@ import socket
 import pytest
 
 from pytest_server_fixtures import CONFIG
+from pytest_fixture_config import requires_config
 
 from .base import TestServer
 
@@ -24,6 +25,7 @@ def _redis_server(request):
     return test_server
 
 
+@requires_config(CONFIG, ['redis_executable'])
 @pytest.fixture(scope='function')
 def redis_server(request):
     """ Function-scoped Redis server in a local thread.
@@ -36,6 +38,7 @@ def redis_server(request):
     return _redis_server(request)
 
 
+@requires_config(CONFIG, ['redis_executable'])
 @pytest.fixture(scope='session')
 def redis_server_sess(request):
     """ Same as redis_server fixture, scoped for test session

--- a/pytest-server-fixtures/pytest_server_fixtures/rethink.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/rethink.py
@@ -5,6 +5,7 @@ import logging
 import pytest
 
 from pytest_server_fixtures import CONFIG
+from pytest_fixture_config import requires_config
 
 from .base import TestServer
 
@@ -23,6 +24,7 @@ def _rethink_server(request):
     return test_server
 
 
+@requires_config(CONFIG, ['rethink_executable'])
 @pytest.fixture(scope='function')
 def rethink_server(request):
     """ Function-scoped RethinkDB server in a local thread.
@@ -36,6 +38,7 @@ def rethink_server(request):
     return _rethink_server(request)
 
 
+@requires_config(CONFIG, ['rethink_executable'])
 @pytest.fixture(scope='session')
 def rethink_server_sess(request):
     """ Same as rethink_server fixture, scoped as session instead.

--- a/pytest-server-fixtures/pytest_server_fixtures/rethink.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/rethink.py
@@ -24,8 +24,8 @@ def _rethink_server(request):
     return test_server
 
 
-@requires_config(CONFIG, ['rethink_executable'])
 @pytest.fixture(scope='function')
+@requires_config(CONFIG, ['rethink_executable'])
 def rethink_server(request):
     """ Function-scoped RethinkDB server in a local thread.
 
@@ -38,8 +38,8 @@ def rethink_server(request):
     return _rethink_server(request)
 
 
-@requires_config(CONFIG, ['rethink_executable'])
 @pytest.fixture(scope='session')
+@requires_config(CONFIG, ['rethink_executable'])
 def rethink_server_sess(request):
     """ Same as rethink_server fixture, scoped as session instead.
     """

--- a/pytest-server-fixtures/pytest_server_fixtures/s3.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/s3.py
@@ -26,8 +26,8 @@ def _s3_server(request):
     return server
 
 
-@requires_config(CONFIG, ['minio_executable'])
 @pytest.fixture(scope="session")
+@requires_config(CONFIG, ['minio_executable'])
 def s3_server(request):
     """
     Creates a session-scoped temporary S3 server using the 'minio' tool.

--- a/pytest-server-fixtures/pytest_server_fixtures/s3.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/s3.py
@@ -12,6 +12,7 @@ import os
 
 import pytest
 from future.utils import text_type
+from pytest_fixture_config import requires_config
 
 from . import CONFIG
 from .http import HTTPTestServer
@@ -25,6 +26,7 @@ def _s3_server(request):
     return server
 
 
+@requires_config(CONFIG, ['minio_executable'])
 @pytest.fixture(scope="session")
 def s3_server(request):
     """

--- a/pytest-server-fixtures/pytest_server_fixtures/xvfb.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/xvfb.py
@@ -13,8 +13,8 @@ from pytest_fixture_config import yield_requires_config
 from pytest_server_fixtures import CONFIG
 
 
-@yield_requires_config(CONFIG, ['xvfb_executable'])
 @pytest.yield_fixture(scope='function')
+@yield_requires_config(CONFIG, ['xvfb_executable'])
 def xvfb_server():
     """ Function-scoped Xvfb (X-Windows Virtual Frame Buffer) in a local thread.
     """
@@ -23,8 +23,8 @@ def xvfb_server():
     test_server.close()
 
 
-@yield_requires_config(CONFIG, ['xvfb_executable'])
 @pytest.yield_fixture(scope='session')
+@yield_requires_config(CONFIG, ['xvfb_executable'])
 def xvfb_server_sess():
     """ Session-scoped Xvfb (X-Windows Virtual Frame Buffer) in a local thread.
     """

--- a/pytest-server-fixtures/pytest_server_fixtures/xvfb.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/xvfb.py
@@ -8,10 +8,12 @@ from tempfile import mkdtemp
 import pytest
 
 from pytest_shutil.workspace import Workspace
+from pytest_fixture_config import yield_requires_config
 
 from pytest_server_fixtures import CONFIG
 
 
+@yield_requires_config(CONFIG, ['xvfb_executable'])
 @pytest.yield_fixture(scope='function')
 def xvfb_server():
     """ Function-scoped Xvfb (X-Windows Virtual Frame Buffer) in a local thread.
@@ -21,6 +23,7 @@ def xvfb_server():
     test_server.close()
 
 
+@yield_requires_config(CONFIG, ['xvfb_executable'])
 @pytest.yield_fixture(scope='session')
 def xvfb_server_sess():
     """ Session-scoped Xvfb (X-Windows Virtual Frame Buffer) in a local thread.

--- a/pytest-virtualenv/pytest_virtualenv.py
+++ b/pytest-virtualenv/pytest_virtualenv.py
@@ -13,7 +13,7 @@ except ImportError:
 
 from pytest_shutil.workspace import Workspace
 from pytest_shutil import run, cmdline
-from pytest_fixture_config import Config
+from pytest_fixture_config import Config, yield_requires_config
 
 
 class FixtureConfig(Config):
@@ -28,6 +28,7 @@ CONFIG = FixtureConfig(
 )
 
 
+@yield_requires_config(CONFIG, ['virtualenv_executable'])
 @yield_fixture(scope='function')
 def virtualenv():
     """ Function-scoped virtualenv in a temporary workspace.

--- a/pytest-virtualenv/pytest_virtualenv.py
+++ b/pytest-virtualenv/pytest_virtualenv.py
@@ -28,8 +28,8 @@ CONFIG = FixtureConfig(
 )
 
 
-@yield_requires_config(CONFIG, ['virtualenv_executable'])
 @yield_fixture(scope='function')
+@yield_requires_config(CONFIG, ['virtualenv_executable'])
 def virtualenv():
     """ Function-scoped virtualenv in a temporary workspace.
 


### PR DESCRIPTION
Fix docs and tests due to pytest 3.7.1
    
pytest 3.7.1 changed behavior for fixture decorators. But later in 3.7.2 this was fixed by adding of ```__pytest_wrapped__``` attribute, which is used to obtain the function up until the point a function was wrapped by pytest itself.

For related info please look at https://github.com/pytest-dev/pytest/pull/3780

Removing of functionality is a surprise for most users/developers.
Meanwhile, fixture_config is used by setuptools for testing.
    
