### PR TITLE
Fix broken link to path.py documentation

### DIFF
--- a/pytest-git/README.md
+++ b/pytest-git/README.md
@@ -25,7 +25,7 @@ Here's a noddy test case that shows it working:
 ```python
 def test_git_repo(git_repo):
     # The fixture derives from `workspace` in `pytest-shutil`, so they contain 
-    # a handle to the path.py path object (see https://pythonhosted.org/path.py)
+    # a handle to the path.py path object (see https://pathpy.readthedocs.io/)
     path = git_repo.workspace
     file = path / 'hello.txt'
     file.write_text('hello world!')

--- a/pytest-shutil/README.md
+++ b/pytest-shutil/README.md
@@ -23,7 +23,7 @@ The workspace fixture is simply a temporary directory at function-scope with a f
     pytest_plugins = ['pytest_shutil']
     
     def test_something(workspace):
-        # Workspaces contain a handle to the path.py path object (see https://pythonhosted.org/path.py)
+        # Workspaces contain a handle to the path.py path object (see https://pathpy.readthedocs.io/)
         path = workspace.workspace         
         script = path / 'hello.sh'
         script.write_text('#!/bin/sh\n echo hello world!')

--- a/pytest-svn/README.md
+++ b/pytest-svn/README.md
@@ -24,7 +24,7 @@ Here's a noddy test case that shows it working:
 ```python
 def test_svn_repo(svn_repo):
     # The fixture derives from `workspace` in `pytest-shutil`, so they contain 
-    # a handle to the path.py path object (see https://pythonhosted.org/path.py)
+    # a handle to the path.py path object (see https://pathpy.readthedocs.io/)
     path = svn_repo.workspace
     file = path / 'hello.txt'
     file.write_text('hello world!')

--- a/pytest-virtualenv/README.md
+++ b/pytest-virtualenv/README.md
@@ -30,7 +30,7 @@ This fixture is configured using the following evironment variables
 ## Fixture Attributes
 
 Here's a noddy test case to demonstrate the basic fixture attributes. 
-For more information on `path.py` see https://pythonhosted.org/path.py
+For more information on `path.py` see https://pathpy.readthedocs.io/
 
 ```python
 def test_virtualenv(virtualenv):


### PR DESCRIPTION
The previous link gives error 404