### PR TITLE
add PYTEST_DONT_REWRITE in order to suppress module already imported

### DIFF
--- a/pytest-listener/pytest_listener.py
+++ b/pytest-listener/pytest_listener.py
@@ -1,3 +1,5 @@
+"""pytest: avoid already-imported warning: PYTEST_DONT_REWRITE."""
+
 import collections
 import json
 import logging

--- a/pytest-profiling/pytest_profiling.py
+++ b/pytest-profiling/pytest_profiling.py
@@ -1,3 +1,5 @@
+"""pytest: avoid already-imported warning: PYTEST_DONT_REWRITE."""
+
 from __future__ import absolute_import
 
 import sys

--- a/pytest-webdriver/pytest_webdriver.py
+++ b/pytest-webdriver/pytest_webdriver.py
@@ -1,3 +1,5 @@
+"""pytest: avoid already-imported warning: PYTEST_DONT_REWRITE."""
+
 import os
 import traceback
 import logging


### PR DESCRIPTION
After calling pytest.main twice, pytest creates this `warning summary `

```bash
===================================================================== warnings summary =====================================================================
~/lib/python2.7/site-packages/_pytest/assertion/rewrite.py:272
~/lib/python2.7/site-packages/_pytest/assertion/rewrite.py:272: PytestWarning: Module already imported so cannot be rewritten: pytest_profiling
    self.config,
...
```
According to 
 * https://github.com/pytest-dev/pytest/issues/2995
 * https://github.com/pytest-dev/pytest-cov/pull/228/commits/22387a604ce8a082cc6381f1bbc28fa434c97bbe

the doc string `PYTEST_DONT_REWRITE` can be used to suppress this warning.