### PR TITLE
pytest-server-fixtures: suppress stacktrace if kill() is called

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 
 ### 1.6.1 (Unrelease)
  * pytest-server-fixtures: fix exception when attempting to access hostname while server is not started
+ * pytest-server-fixtures: suppress stacktrace if kill() is called
 
 ### 1.6.0 (2019-02-12)
  * pytest-server-fixtures: added previously removed TestServerV2.kill() function

--- a/pytest-server-fixtures/pytest_server_fixtures/base2.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/base2.py
@@ -84,6 +84,10 @@ class TestServerV2(Workspace):
         if not self._server:
             log.debug("Server not started yet, skipping")
             return
+
+        # Prevent traceback printed when the server goes away as we kill it
+        self._server.exit = True
+
         self._server.teardown()
         self._server = None
         self._killed = True


### PR DESCRIPTION
this prevents the following error:

"Fatal Python error: could not acquire lock for <_io.BufferedWriter name='<stderr>'> at interpreter shutdown, possibly due to daemon threads"