### PR TITLE
Error if hostname not defined

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,12 @@
 
 ## Changelog
 
-### 1.6.2 (Unreleased)
+### 1.7.0
+  * pytest-server-fixtures: if host not defined, use localhost
+
+### 1.6.2 (2019-02-21)
  * pytest-server-fixtures: suppress stacktrace if kill() is called
  * pytest-server-fixtures: fix random port logic in TestServerV2
- * pytest-server-fixtures: if host not defined, use localhost
 
 ### 1.6.1 (2019-02-12)
  * pytest-server-fixtures: fix exception when attempting to access hostname while server is not started

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 ### 1.6.2 (Unreleased)
  * pytest-server-fixtures: suppress stacktrace if kill() is called
  * pytest-server-fixtures: fix random port logic in TestServerV2
+ * pytest-server-fixtures: if host not defined, use localhost
 
 ### 1.6.1 (2019-02-12)
  * pytest-server-fixtures: fix exception when attempting to access hostname while server is not started

--- a/pytest-server-fixtures/pytest_server_fixtures/__init__.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/__init__.py
@@ -35,7 +35,10 @@ class FixtureConfig(Config):
     )
 
 # Default values for system resource locations - patch this to change defaults
-DEFAULT_SERVER_FIXTURES_HOSTNAME = socket.gethostbyname(socket.gethostname())
+try:
+    DEFAULT_SERVER_FIXTURES_HOSTNAME = socket.gethostbyname(socket.gethostname())
+except socket.gaierror:
+    DEFAULT_SERVER_FIXTURES_HOSTNAME = '127.0.0.1'
 DEFAULT_SERVER_FIXTURES_SESSION_ID = get_random_id(SESSION_ID_LEN)
 DEFAULT_SERVER_FIXTURES_DISABLE_HTTP_PROXY = True
 DEFAULT_SERVER_FIXTURES_SERVER_CLASS = 'thread'


### PR DESCRIPTION
Locally I constantly get #127 because I dont have a host defined on my laptop. This is a reasonable workaround (in my opinion).