### PR TITLE
Add support for pytest 4.x and test against python 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,8 @@ test-tmpl: &test-tmpl
     cat *.egg-info/top_level.txt  | xargs -Ipysrc coverage run -p --source=pysrc setup.py test -sv -ra || touch ../FAILED-$(basename $PWD)
 
 job-tmpl: &job-tmpl
-  machine: true
+  machine:
+    image: circleci/classic:201808-01
 
   working_directory: ~/src
 
@@ -118,7 +119,11 @@ job-tmpl: &job-tmpl
           coverage report
           pip install urllib3[secure]
           pip install coveralls
-          CIRCLE_BUILD_NUM=$CIRCLE_WORKFLOW_ID coveralls
+          if [[ "$COVERALLS_REPO_TOKEN" != "" ]]; then
+            CIRCLE_BUILD_NUM=$CIRCLE_WORKFLOW_ID coveralls
+          else
+            echo "Skipping Coveralls"
+          fi
 
     - store_test_results:
         path: junit
@@ -148,13 +153,23 @@ jobs:
     environment:
       PYTHON: "python3.6"
 
+  py37:
+    <<: *job-tmpl
+    environment:
+      PYTHON: "python3.7"
+
   coveralls:
     docker:
       - image: buildpack-deps:trusty
     steps:
       - run:
           name: Complete Coveralls
-          command: curl --fail https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$CIRCLE_WORKFLOW_ID&payload[status]=done"
+          command: |
+            if [[ "$COVERALLS_REPO_TOKEN" != "" ]]; then
+              curl --fail https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$CIRCLE_WORKFLOW_ID&payload[status]=done"
+            else
+              echo "Skipping Coveralls"
+            fi
 
 workflows:
   version: 2
@@ -164,9 +179,11 @@ workflows:
       - py34
       - py35
       - py36
+      - py37
       - coveralls:
           requires:
             - py27
             - py34
             - py35
             - py36
+            - py37

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,19 @@
 ## Changelog
 
 ### 1.7.0
-  * pytest-server-fixtures: if host not defined, use localhost
+ * pytest-server-fixtures: if host not defined, use localhost
+ * circleci: Test against Python 3.7
+ * circleci: Fix checks by skipping coverall submission for developer without push access
+ * pytest-server-fixture: Fix rethinkdb tests requiring rethinkdb < 2.4.0
+ * wheels: Generate universal wheels installable with both python 2.x and 3.x
+ * Fix DeprecationWarning warnings using "logger.warning()" function
+ * pytest-virtualenv: Add virtualenv as install requirement. Fixes #122
+ * Remove requirement for pytest<4.0.0
+ * pytest-webdriver: Fix RemovedInPytest4Warning using getfixturevalue
+ * pytest-verbose-parametrize: Add support for revamped marker infrastructure
+ * pytest-verbose-parametrize: Fix integration tests to support pytest >= 4.1.0
+ * dist: Remove support for building and distributing *.egg files
+ * VagrantFile: Install python 3.7 and initialize python 3.7 by default
 
 ### 1.6.2 (2019-02-21)
  * pytest-server-fixtures: suppress stacktrace if kill() is called

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ EXTRA_DEPS = pypandoc       \
              pymongo        \
              psycopg2       \
              boto3          \
-             rethinkdb      \
+             "rethinkdb<2.4.0" \
              docker         \
              kubernetes
 
@@ -16,7 +16,7 @@ COPY_FILES = VERSION CHANGES.md common_setup.py MANIFEST.in LICENSE
 UPLOAD_OPTS =
 
 # removed from PHONY:  circleci_sip circleci_pyqt
-.PHONY: extras copyfiles wheels eggs sdists install develop test upload clean
+.PHONY: extras copyfiles wheels sdists install develop test upload clean
 
 extras:
 	pip install $(EXTRA_DEPS)
@@ -27,9 +27,6 @@ copyfiles:
 wheels: copyfiles
 	pip install -U wheel
 	./foreach.sh --changed 'python setup.py bdist_wheel'
-
-eggs: copyfiles
-	./foreach.sh --changed 'python setup.py bdist_egg'
 
 sdists: copyfiles
 	./foreach.sh --changed 'python setup.py sdist'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,5 +18,5 @@ Vagrant.configure("2") do |config|
   config.vm.provision "docker"
   config.vm.provision "file", source: "install.sh", destination: "/tmp/install.sh"
   config.vm.provision "shell", inline: ". /tmp/install.sh && install_all"
-  config.vm.provision "shell", inline: ". /tmp/install.sh && init_venv python2.7", privileged: false
+  config.vm.provision "shell", inline: ". /tmp/install.sh && init_venv python3.7", privileged: false
 end

--- a/install.sh
+++ b/install.sh
@@ -140,6 +140,7 @@ function install_all {
   install_python python3.4
   install_python python3.5
   install_python python3.6
+  install_python python3.7
 
   update_apt_sources
   install_system_deps

--- a/pytest-devpi-server/README.md
+++ b/pytest-devpi-server/README.md
@@ -13,8 +13,6 @@ Install using your favourite package manager:
 
 ```bash
     pip install pytest-devpi-server
-    #  or..
-    easy_install pytest-devpi-server
 ```
 
 Enable the fixture explicitly in your tests or conftest.py (not required when using setuptools entry points):

--- a/pytest-devpi-server/setup.cfg
+++ b/pytest-devpi-server/setup.cfg
@@ -1,8 +1,11 @@
 [tool:pytest]
 # This section sets configuration for all invocations of py.test,
 # both standalone cmdline and running via setup.py
-norecursedirs = 
-	.git 
-	*.egg 
-	build 
+norecursedirs =
+	.git
+	*.egg
+	build
 	dist
+
+[bdist_wheel]
+universal = 1

--- a/pytest-devpi-server/setup.py
+++ b/pytest-devpi-server/setup.py
@@ -20,10 +20,11 @@ classifiers = [
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
 ]
 
 install_requires = ['pytest-server-fixtures',
-                    'pytest<4.0.0',
+                    'pytest',
                     'devpi-server>=3.0.1',
                     'devpi-client',
                     'six',

--- a/pytest-fixture-config/README.md
+++ b/pytest-fixture-config/README.md
@@ -9,8 +9,6 @@ Install using your favourite package manager:
 
 ```bash
     pip install pytest-fixture-config
-    #  or..
-    easy_install pytest-fixture-config
 ```
 
 Enable the fixture explicitly in your tests or conftest.py (not required when using setuptools entry points):

--- a/pytest-fixture-config/setup.cfg
+++ b/pytest-fixture-config/setup.cfg
@@ -1,8 +1,11 @@
 [tool:pytest]
 # This section sets configuration for all invocations of py.test,
 # both standalone cmdline and running via setup.py
-norecursedirs = 
-	.git 
-	*.egg 
-	build 
+norecursedirs =
+	.git
+	*.egg
+	build
 	dist
+
+[bdist_wheel]
+universal = 1

--- a/pytest-fixture-config/setup.py
+++ b/pytest-fixture-config/setup.py
@@ -19,9 +19,10 @@ classifiers = [
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
 ]
 
-install_requires = ['pytest<4.0.0']
+install_requires = ['pytest']
 
 tests_require = ['six',
                  ]

--- a/pytest-git/README.md
+++ b/pytest-git/README.md
@@ -7,8 +7,6 @@ Creates an empty Git repository for testing that cleans up after itself on teard
 Install using your favourite package installer:
 ```bash
     pip install pytest-git
-    # or
-    easy_install pytest-git
 ```
     
 Enable the fixture explicitly in your tests or conftest.py (not required when using setuptools entry points):

--- a/pytest-git/setup.cfg
+++ b/pytest-git/setup.cfg
@@ -1,8 +1,11 @@
 [tool:pytest]
 # This section sets configuration for all invocations of py.test,
 # both standalone cmdline and running via setup.py
-norecursedirs = 
-	.git 
-	*.egg 
-	build 
+norecursedirs =
+	.git
+	*.egg
+	build
 	dist
+
+[bdist_wheel]
+universal = 1

--- a/pytest-git/setup.py
+++ b/pytest-git/setup.py
@@ -19,9 +19,10 @@ classifiers = [
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
 ]
 
-install_requires = ['pytest<4.0.0',
+install_requires = ['pytest',
                     'pytest-shutil',
                     'gitpython',
                     ]

--- a/pytest-listener/README.md
+++ b/pytest-listener/README.md
@@ -8,8 +8,6 @@ Install using your favourite package manager:
 
 ```bash
     pip install pytest-listener
-    #  or..
-    easy_install pytest-listener
 ```
 
 Enable the fixture explicitly in your tests or conftest.py (not required when using setuptools entry points):

--- a/pytest-listener/setup.cfg
+++ b/pytest-listener/setup.cfg
@@ -1,8 +1,11 @@
 [tool:pytest]
 # This section sets configuration for all invocations of py.test,
 # both standalone cmdline and running via setup.py
-norecursedirs = 
-	.git 
-	*.egg 
-	build 
+norecursedirs =
+	.git
+	*.egg
+	build
 	dist
+
+[bdist_wheel]
+universal = 1

--- a/pytest-listener/setup.py
+++ b/pytest-listener/setup.py
@@ -19,10 +19,11 @@ classifiers = [
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
 ]
 
 install_requires = ['six',
-                    'pytest<4.0.0',
+                    'pytest',
                     'pytest-server-fixtures'
                     ]
 

--- a/pytest-profiling/README.md
+++ b/pytest-profiling/README.md
@@ -13,8 +13,6 @@ generated using [gprof2dot](http://code.google.com/p/jrfonseca/wiki/Gprof2Dot) a
 Install using your favourite package installer:
 ```bash
     pip install pytest-profiling
-    # or
-    easy_install pytest-profiling
 ```
     
 Enable the fixture explicitly in your tests or conftest.py (not required when using setuptools entry points):

--- a/pytest-profiling/setup.cfg
+++ b/pytest-profiling/setup.cfg
@@ -1,9 +1,12 @@
 [tool:pytest]
 # This section sets configuration for all invocations of py.test,
 # both standalone cmdline and running via setup.py
-norecursedirs = 
-	.git 
-	*.egg 
-	build 
+norecursedirs =
+	.git
+	*.egg
+	build
 	dist
 	tests/integration/profile/tests
+
+[bdist_wheel]
+universal = 1

--- a/pytest-profiling/setup.py
+++ b/pytest-profiling/setup.py
@@ -19,10 +19,11 @@ classifiers = [
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
 ]
 
 install_requires = ['six',
-                    'pytest<4.0.0',
+                    'pytest',
                     'gprof2dot',
                     ]
 

--- a/pytest-pyramid-server/README.md
+++ b/pytest-pyramid-server/README.md
@@ -10,8 +10,6 @@ Install using your favourite package manager:
 
 ```bash
     pip install pytest-pyramid-server
-    #  or..
-    easy_install pytest-pyramid-server
 ```
 
 Enable the fixture explicitly in your tests or conftest.py (not required when using setuptools entry points):

--- a/pytest-pyramid-server/setup.cfg
+++ b/pytest-pyramid-server/setup.cfg
@@ -1,8 +1,11 @@
 [tool:pytest]
 # This section sets configuration for all invocations of py.test,
 # both standalone cmdline and running via setup.py
-norecursedirs = 
-	.git 
-	*.egg 
-	build 
+norecursedirs =
+	.git
+	*.egg
+	build
 	dist
+
+[bdist_wheel]
+universal = 1

--- a/pytest-pyramid-server/setup.py
+++ b/pytest-pyramid-server/setup.py
@@ -20,11 +20,12 @@ classifiers = [
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
 ]
 
 
 install_requires = ['pytest-server-fixtures',
-                    'pytest<4.0.0',
+                    'pytest',
                     'pyramid',
                     'waitress',
                     'six',

--- a/pytest-qt-app/README.md
+++ b/pytest-qt-app/README.md
@@ -7,8 +7,6 @@ Set up a Q Application for QT with an X-Window Virtual Framebuffer (Xvfb).
 Install using your favourite package installer:
 ```bash
     pip install pytest-qt-app
-    # or
-    easy_install pytest-qt-app
 ```
     
 Enable the fixture explicitly in your tests or conftest.py (not required when using setuptools entry points):

--- a/pytest-qt-app/setup.cfg
+++ b/pytest-qt-app/setup.cfg
@@ -1,8 +1,11 @@
 [tool:pytest]
 # This section sets configuration for all invocations of py.test,
 # both standalone cmdline and running via setup.py
-norecursedirs = 
-	.git 
-	*.egg 
-	build 
+norecursedirs =
+	.git
+	*.egg
+	build
 	dist
+
+[bdist_wheel]
+universal = 1

--- a/pytest-qt-app/setup.py
+++ b/pytest-qt-app/setup.py
@@ -19,9 +19,10 @@ classifiers = [
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
 ]
 
-install_requires = ['pytest<4.0.0',
+install_requires = ['pytest',
                     'pytest-server-fixtures',
                     'pytest-shutil',
                     ]

--- a/pytest-server-fixtures/pytest_server_fixtures/rethink.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/rethink.py
@@ -178,5 +178,5 @@ class RethinkDBServer(TestServerV2):
                                           port=self.port, db='test')
             return True
         except rethinkdb.RqlDriverError as err:
-            log.warn(err)
+            log.warning(err)
         return False

--- a/pytest-server-fixtures/setup.cfg
+++ b/pytest-server-fixtures/setup.cfg
@@ -1,8 +1,11 @@
 [tool:pytest]
 # This section sets configuration for all invocations of py.test,
 # both standalone cmdline and running via setup.py
-norecursedirs = 
-	.git 
-	*.egg 
-	build 
+norecursedirs =
+	.git
+	*.egg
+	build
 	dist
+
+[bdist_wheel]
+universal = 1

--- a/pytest-server-fixtures/setup.py
+++ b/pytest-server-fixtures/setup.py
@@ -19,9 +19,10 @@ classifiers = [
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
 ]
 
-install_requires = ['pytest<4.0.0',
+install_requires = ['pytest',
                     'pytest-shutil',
                     'pytest-fixture-config',
                     'six',
@@ -35,7 +36,7 @@ extras_require = {
     'jenkins':  ["python-jenkins"],
     'mongodb':  ["pymongo>=3.6.0"],
     'postgres': ["psycopg2"],
-    'rethinkdb':  ["rethinkdb"],
+    'rethinkdb':  ["rethinkdb<2.4.0"],
     'redis':  ["redis"],
     's3': ["boto3"],
     'docker': ["docker"],

--- a/pytest-shutil/README.md
+++ b/pytest-shutil/README.md
@@ -10,9 +10,7 @@ Install using your favourite package manager::
 
 ```bash
     pip install pytest-shutil
-    #  or..
-    easy_install pytest-shutil
-```               
+```
 
 ## Workspace Fixture
 

--- a/pytest-shutil/pytest_shutil/cmdline.py
+++ b/pytest-shutil/pytest_shutil/cmdline.py
@@ -40,7 +40,7 @@ def chdir(dirname):
     try:
         here = os.getcwd()
     except OSError:
-        get_log().warn("CWD has gone away, will chdir to back to '/'")
+        get_log().warning("CWD has gone away, will chdir to back to '/'")
         here = '/'
     try:
         os.chdir(dirname)

--- a/pytest-shutil/pytest_shutil/run.py
+++ b/pytest-shutil/pytest_shutil/run.py
@@ -67,7 +67,7 @@ def run(cmd, stdin=None, capture_stdout=True, capture_stderr=False,
         try:
             out = out.decode('utf-8')
         except:
-            log.warn("Unable to decode command output to UTF-8")
+            log.warning("Unable to decode command output to UTF-8")
 
     if check_rc and p.returncode != 0:
         err_msg = ((out if out else 'No output') if capture_stdout is True

--- a/pytest-shutil/setup.cfg
+++ b/pytest-shutil/setup.cfg
@@ -1,8 +1,11 @@
 [tool:pytest]
 # This section sets configuration for all invocations of py.test,
 # both standalone cmdline and running via setup.py
-norecursedirs = 
-	.git 
-	*.egg 
-	build 
+norecursedirs =
+	.git
+	*.egg
+	build
 	dist
+
+[bdist_wheel]
+universal = 1

--- a/pytest-shutil/setup.py
+++ b/pytest-shutil/setup.py
@@ -19,12 +19,13 @@ classifiers = [
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
 ]
 
 install_requires = ['six',
                     'execnet',
                     'contextlib2',
-                    'pytest<4.0.0',
+                    'pytest',
                     'path.py',
                     'mock',
                     'termcolor'

--- a/pytest-svn/README.md
+++ b/pytest-svn/README.md
@@ -7,8 +7,6 @@ Creates an empty SVN repository for testing that cleans up after itself on teard
 Install using your favourite package installer:
 ```bash
     pip install pytest-svn
-    # or
-    easy_install pytest-svn
 ```
     
 Enable the fixture explicitly in your tests or conftest.py (not required when using setuptools entry points):

--- a/pytest-svn/setup.cfg
+++ b/pytest-svn/setup.cfg
@@ -1,8 +1,11 @@
 [tool:pytest]
 # This section sets configuration for all invocations of py.test,
 # both standalone cmdline and running via setup.py
-norecursedirs = 
-	.git 
-	*.egg 
-	build 
+norecursedirs =
+	.git
+	*.egg
+	build
 	dist
+
+[bdist_wheel]
+universal = 1

--- a/pytest-svn/setup.py
+++ b/pytest-svn/setup.py
@@ -19,9 +19,10 @@ classifiers = [
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
 ]
 
-install_requires = ['pytest<4.0.0',
+install_requires = ['pytest',
                     'pytest-shutil',
                     ]
 

--- a/pytest-verbose-parametrize/README.md
+++ b/pytest-verbose-parametrize/README.md
@@ -8,8 +8,6 @@ more descriptive than the default (which just outputs id numbers).
 Install with your favourite package manager, and this plugin will automatically be enabled:
 ```bash
 pip install pytest-verbose-parametrize
-# or .. 
-easy_install pytest-verbose-parametrize
 ```
 ## Usage
 

--- a/pytest-verbose-parametrize/pytest_verbose_parametrize.py
+++ b/pytest-verbose-parametrize/pytest_verbose_parametrize.py
@@ -13,10 +13,19 @@ def _strize_arg(arg):
 
 
 def pytest_generate_tests(metafunc):
+
     try:
-        markers = metafunc.function.parametrize
+        markers = metafunc.definition.get_closest_marker('parametrize')
+        if not markers:
+            return
     except AttributeError:
-        return
+        # Deprecated in pytest >= 3.6
+        # See https://docs.pytest.org/en/latest/mark.html#marker-revamp-and-iteration
+        try:
+            markers = metafunc.function.parametrize
+        except AttributeError:
+            return
+
     if 'ids' not in markers.kwargs:
         list_names = []
         for i, argvalue in enumerate(markers.args[1]):

--- a/pytest-verbose-parametrize/setup.cfg
+++ b/pytest-verbose-parametrize/setup.cfg
@@ -1,9 +1,12 @@
 [tool:pytest]
 # This section sets configuration for all invocations of py.test,
 # both standalone cmdline and running via setup.py
-norecursedirs = 
-	.git 
-	*.egg 
-	build 
+norecursedirs =
+	.git
+	*.egg
+	build
 	dist
 	tests/integration/parametrize_ids
+
+[bdist_wheel]
+universal = 1

--- a/pytest-verbose-parametrize/setup.py
+++ b/pytest-verbose-parametrize/setup.py
@@ -19,9 +19,10 @@ classifiers = [
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
 ]
 
-install_requires = ['pytest<4.0.0',
+install_requires = ['pytest',
                     'six',
                     ]
 

--- a/pytest-verbose-parametrize/tests/integration/test_verbose_parametrize.py
+++ b/pytest-verbose-parametrize/tests/integration/test_verbose_parametrize.py
@@ -9,6 +9,17 @@ TEST_DIR = resource_filename('pytest_verbose_parametrize', 'tests/integration/pa
 PYTEST = os.path.join(os.path.dirname(sys.executable), 'py.test')
 
 
+def _update_expected(expected, output):
+    """If pytest >= 4.1.0 is used, remove single quotes from expected output.
+
+    This function allows to successfully assert output using version of pytest
+    with or without pytest-dev/pytest@e9b2475e2 (Display actual test ids in `--collect-only`)
+    introduced in version 4.1.0.
+    """
+    pytest_410_and_above = ".py'>" not in output
+    return expected.replace("'", "") if pytest_410_and_above else expected
+
+
 def test_parametrize_ids_generates_ids(pytestconfig):
     output = run_with_coverage([PYTEST, '--collectonly', 'tests/unit/test_parametrized.py'],
                                 pytestconfig, cd=TEST_DIR)
@@ -16,6 +27,7 @@ def test_parametrize_ids_generates_ids(pytestconfig):
   <Function 'test_foo[sum-list]'>
   <Function 'test_foo[len-int]'>
 '''
+    expected = _update_expected(expected, output)
     assert expected in output
 
 
@@ -25,6 +37,7 @@ def test_parametrize_ids_leaves_nonparametrized(pytestconfig):
     expected = '''<Module 'tests/integration/parametrize_ids/tests/unit/test_non_parametrized.py'>
   <Function 'test_bar'>
 '''
+    expected = _update_expected(expected, output)
     assert expected in output
 
 
@@ -36,6 +49,7 @@ def test_handles_apparent_duplicates(pytestconfig):
   <Function 'test_foo[0-[1]#1]'>
   <Function 'test_foo[0-[1]#2]'>
 '''
+    expected = _update_expected(expected, output)
     assert expected in output
 
 
@@ -45,4 +59,5 @@ def test_truncates_long_ids(pytestconfig):
     expected = '''<Module 'tests/integration/parametrize_ids/tests/unit/test_long_ids.py'>
   <Function 'test_foo[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9...-None]'>
 '''
+    expected = _update_expected(expected, output)
     assert expected in output

--- a/pytest-verbose-parametrize/tests/unit/test_verbose_parametrize.py
+++ b/pytest-verbose-parametrize/tests/unit/test_verbose_parametrize.py
@@ -8,8 +8,10 @@ def get_metafunc(args):
     p = Mock(kwargs={}, args=args)
     p._arglist = ([args, {}],)
     metafunc = Mock()
-    metafunc.function.parametrize = p
+    metafunc.function.parametrize = p  # Deprecated
+    metafunc.definition.get_closest_marker.return_value = p
     return metafunc
+
 
 def test_generates_ids_from_tuple():
     metafunc = get_metafunc((None, [(1, 2, 3)]))

--- a/pytest-virtualenv/README.md
+++ b/pytest-virtualenv/README.md
@@ -8,8 +8,6 @@ The fixture has utility methods to install packages and list what's installed.
 Install using your favourite package installer:
 ```bash
     pip install pytest-virtualenv
-    # or
-    easy_install pytest-virtualenv
 ```
     
 Enable the fixture explicitly in your tests or conftest.py (not required when using setuptools entry points):

--- a/pytest-virtualenv/setup.cfg
+++ b/pytest-virtualenv/setup.cfg
@@ -1,8 +1,11 @@
 [tool:pytest]
 # This section sets configuration for all invocations of py.test,
 # both standalone cmdline and running via setup.py
-norecursedirs = 
-	.git 
-	*.egg 
-	build 
+norecursedirs =
+	.git
+	*.egg
+	build
 	dist
+
+[bdist_wheel]
+universal = 1

--- a/pytest-virtualenv/setup.py
+++ b/pytest-virtualenv/setup.py
@@ -19,11 +19,13 @@ classifiers = [
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
 ]
 
 install_requires = ['pytest-fixture-config',
                     'pytest-shutil',
-                    'pytest<4.0.0',
+                    'pytest',
+                    'virtualenv',
                     ]
 
 tests_require = [

--- a/pytest-webdriver/README.md
+++ b/pytest-webdriver/README.md
@@ -9,8 +9,6 @@ on test failures.
 Install using your favourite package installer:
 ```bash
     pip install pytest-webdriver
-    # or
-    easy_install pytest-webdriver
 ```
     
 Enable the fixture explicitly in your tests or conftest.py (not required when using setuptools entry points):

--- a/pytest-webdriver/pytest_webdriver.py
+++ b/pytest-webdriver/pytest_webdriver.py
@@ -59,7 +59,7 @@ def webdriver(request):
     # Look for the pyramid server funcarg in the current session, and save away its root uri
     root_uri = []
     try:
-        root_uri.append(request.getfuncargvalue('pyramid_server').uri)
+        root_uri.append(request.getfixturevalue('pyramid_server').uri)
     except LookupError:
         pass
 

--- a/pytest-webdriver/setup.cfg
+++ b/pytest-webdriver/setup.cfg
@@ -1,8 +1,11 @@
 [tool:pytest]
 # This section sets configuration for all invocations of py.test,
 # both standalone cmdline and running via setup.py
-norecursedirs = 
-	.git 
-	*.egg 
-	build 
+norecursedirs =
+	.git
+	*.egg
+	build
 	dist
+
+[bdist_wheel]
+universal = 1

--- a/pytest-webdriver/setup.py
+++ b/pytest-webdriver/setup.py
@@ -19,10 +19,11 @@ classifiers = [
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
 ]
 
 install_requires = ['py',
-                    'pytest<4.0.0',
+                    'pytest',
                     'pytest-fixture-config',
                     'selenium',
                     ]


### PR DESCRIPTION
----
ci: Test against Python 3.7

----
ci: Skip Coveralls submission if COVERALLS_REPO_TOKEN env. var is empty

----
ci: Update circleci image to allow install of python 3.7
See https://circleci.com/docs/2.0/configuration-reference/#machine

----
pytest-server-fixture: Fix rethinkdb tests requiring rethinkdb < 2.4.0

The current implementation needs to be refactored to support the latest
release of rethinkdb-python package. See #132

----
wheels: Generate universal wheels installable with both python 2.x and 3.x
See #125

Fix DeprecationWarning warnings using "logger.warning()" function

----
pytest-virtualenv: Add virtualenv as install requirement. Fixes #122

Remove requirement for pytest<4.0.0
See #100

----
pytest-webdriver: Fix RemovedInPytest4Warning using getfixturevalue

This commit fixes the following error:

  >           root_uri.append(request.getfuncargvalue('pyramid_server').uri)
  E           RemovedInPytest4Warning: getfuncargvalue is deprecated, use getfixturevalue

  pytest_webdriver.py:62: RemovedInPytest4Warning

See #100

----
pytest-verbose-parametrize: Add support for revamped marker infrastructure

This commit fixes tests failing with pytest > 4.0.0

----
pytest-verbose-parametrize: Fix integration tests to support pytest >= 4.1.0

This commit updates tests to support version of pytest with
pytest-dev/pytest@e9b2475e2 (Display actual test ids in `--collect-only`)

----
dist: Remove support for building and distributing *.egg files

Wheel is currently considered the standard for built and binary
packaging for Python

See https://packaging.python.org/discussions/wheel-vs-egg/

See #125

----
VagrantFile: Install python 3.7 and initialize python 3.7 by default