### PR TITLE
Fix pytest-devpi-server test on py34 updating "ruamel.yaml" requirements

### DIFF
--- a/pytest-devpi-server/setup.py
+++ b/pytest-devpi-server/setup.py
@@ -28,6 +28,9 @@ install_requires = ['pytest-server-fixtures',
                     'devpi-server>=3.0.1',
                     'devpi-client',
                     'six',
+                    'ruamel.yaml>=0.15;python_version == "2.7"',
+                    'ruamel.yaml>=0.15,<=0.15.94;python_version == "3.4"',
+                    'ruamel.yaml>=0.15;python_version > "3.4"',
                     ]
 
 tests_require = []


### PR DESCRIPTION
Since no python 3.4 wheels are distributed following ruamel.yaml 0.15.94,
this commit updates the requirements to ensure the package still be installed
using python 3.4

It addresses the following error:

```
  Searching for ruamel.yaml>=0.14.2
  Reading https://pypi.org/simple/ruamel.yaml/
  Downloading https://files.pythonhosted.org/packages/a2/f7/63f04dd8a572b13a41a62b29eb52b64a2136249cc42a933f05d890033eac/ruamel.yaml-0.15.96.tar.gz#sha256=343ace5ffbab036536a3da65e4cfd31b8292388a389f6305744984581a479b2a
  Best match: ruamel.yaml 0.15.96
  Processing ruamel.yaml-0.15.96.tar.gz
  Writing /tmp/easy_install-gpfme0if/ruamel.yaml-0.15.96/setup.cfg
  Running ruamel.yaml-0.15.96/setup.py -q bdist_egg --dist-dir /tmp/easy_install-gpfme0if/ruamel.yaml-0.15.96/egg-dist-tmp-ncvinjfp
  minimum python version(s): [(2, 7), (3, 5)]
  error: Setup script exited with 1
```

Adapted from scikit-build/scikit-ci@d8311a3f393